### PR TITLE
Fix #7 issue. Improve text validation checking if the text to translate is a number or a URL.

### DIFF
--- a/src/main/scala/com/fortysevendeg/translatebubble/modules/clipboard/impl/ClipboardServicesComponentImpl.scala
+++ b/src/main/scala/com/fortysevendeg/translatebubble/modules/clipboard/impl/ClipboardServicesComponentImpl.scala
@@ -20,6 +20,7 @@ import android.content.{ClipData, Context, ClipboardManager}
 import com.fortysevendeg.macroid.extras.AppContextProvider
 import com.fortysevendeg.translatebubble.modules.clipboard._
 import com.fortysevendeg.translatebubble.service._
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -45,7 +46,9 @@ trait ClipboardServicesComponentImpl
     }
 
     private def getClipboardManagerPrimaryClip: Option[ClipData] = Option(clipboardManager.getPrimaryClip)
+
     private def getPrimaryClipItem(clipData: ClipData): Option[ClipData.Item] = Option(clipData.getItemAt(0))
+
     private def getClipDataItemText(clipDataItem: ClipData.Item): Option[CharSequence] = Option(clipDataItem.getText)
 
     override def isValidCall: Boolean = {
@@ -61,7 +64,7 @@ trait ClipboardServicesComponentImpl
       } yield text
 
       result match {
-        case Some(text) if isValidText(text) => lastDate = currentMillis; currentInterval > millisInterval
+        case Some(text) if isValidText(text.toString) => lastDate = currentMillis; currentInterval > millisInterval
         case _ => false
       }
     }
@@ -103,15 +106,11 @@ trait ClipboardServicesComponentImpl
 
   }
 
-  private def isValidText(text: CharSequence): Boolean = {
-    !isTrimmedTextEmpty(text) && !isTextANumber(text) && !isTextAUrl(text)
-  }
+  private def isValidText(text: String): Boolean = text.trim.nonEmpty && !isTextANumber(text) && !isTextAUrl(text)
 
-  private def isTrimmedTextEmpty(text: CharSequence): Boolean = text.toString.trim.length == 0
+  private def isTextANumber(text: String): Boolean = text forall Character.isDigit
 
-  private def isTextANumber(text: CharSequence): Boolean = text.toString forall Character.isDigit
-
-  private def isTextAUrl(text: CharSequence): Boolean = {
+  private def isTextAUrl(text: String): Boolean = {
     text.toString matches "(\\b(https?|ftp|file|ldap)://)?[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]"
   }
 

--- a/src/main/scala/com/fortysevendeg/translatebubble/modules/clipboard/impl/ClipboardServicesComponentImpl.scala
+++ b/src/main/scala/com/fortysevendeg/translatebubble/modules/clipboard/impl/ClipboardServicesComponentImpl.scala
@@ -61,7 +61,7 @@ trait ClipboardServicesComponentImpl
       } yield text
 
       result match {
-        case Some(text) if text.toString.trim.length > 0 => lastDate = currentMillis; currentInterval > millisInterval
+        case Some(text) if isValidText(text) => lastDate = currentMillis; currentInterval > millisInterval
         case _ => false
       }
     }
@@ -101,6 +101,18 @@ trait ClipboardServicesComponentImpl
 
     def reset(): Unit = lastDate = 0
 
+  }
+
+  private def isValidText(text: CharSequence): Boolean = {
+    !isTrimmedTextEmpty(text) && !isTextANumber(text) && !isTextAUrl(text)
+  }
+
+  private def isTrimmedTextEmpty(text: CharSequence): Boolean = text.toString.trim.length == 0
+
+  private def isTextANumber(text: CharSequence): Boolean = text.toString forall Character.isDigit
+
+  private def isTextAUrl(text: CharSequence): Boolean = {
+    text.toString matches "(\\b(https?|ftp|file|ldap)://)?[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]"
   }
 
 }

--- a/src/test/scala/com/fortysevendeg/translatebubble/modules/clipboard/ClipboardServiceComponentSpec.scala
+++ b/src/test/scala/com/fortysevendeg/translatebubble/modules/clipboard/ClipboardServiceComponentSpec.scala
@@ -59,6 +59,55 @@ class ClipboardServiceComponentSpec
 
     }
 
+    "ClipboardService should validate text if the text value is not a number" in new ClipboardMocks {
+      val text = "This is not a number"
+      mockClipItem.getText returns text
+
+      clipboardServices.isValidCall shouldEqual true
+    }
+
+    "ClipboardService should not validate text if the text value is a number" in new ClipboardMocks {
+      val number = "47"
+      mockClipItem.getText returns number
+
+      clipboardServices.isValidCall shouldEqual false
+    }
+
+    "ClipboardService should not validate text if the text value is a URL starting with 'https'" in new ClipboardMocks {
+      val url = "https://www.47deg.com"
+      mockClipItem.getText returns url
+
+      clipboardServices.isValidCall shouldEqual false
+    }
+
+    "ClipboardService should not validate text if the text value is a URL starting with 'http'" in new ClipboardMocks {
+      val url = "http://www.47deg.com"
+      mockClipItem.getText returns url
+
+      clipboardServices.isValidCall shouldEqual false
+    }
+
+    "ClipboardService should not validate text if the text value is a URL starting with 'www'" in new ClipboardMocks {
+      val url = "www.47deg.com"
+      mockClipItem.getText returns url
+
+      clipboardServices.isValidCall shouldEqual false
+    }
+
+    "ClipboardService should not validate text if the text value is a URL starting with the domain" in new ClipboardMocks {
+      val url = "47deg.com"
+      mockClipItem.getText returns url
+
+      clipboardServices.isValidCall shouldEqual false
+    }
+
+    "ClipboardService should validate text if the text value is not a URL" in new ClipboardMocks {
+      val text = "This is not a number"
+      mockClipItem.getText returns text
+
+      clipboardServices.isValidCall shouldEqual true
+    }
+
   }
 
 }

--- a/src/test/scala/com/fortysevendeg/translatebubble/modules/clipboard/ClipboardServiceComponentSpec.scala
+++ b/src/test/scala/com/fortysevendeg/translatebubble/modules/clipboard/ClipboardServiceComponentSpec.scala
@@ -59,7 +59,7 @@ class ClipboardServiceComponentSpec
 
     }
 
-    "ClipboardService should validate text if the text value is not a number" in new ClipboardMocks {
+    "ClipboardService should validate text if the text value is not a number neither an url" in new ClipboardMocks {
       val text = "This is not a number"
       mockClipItem.getText returns text
 
@@ -99,13 +99,6 @@ class ClipboardServiceComponentSpec
       mockClipItem.getText returns url
 
       clipboardServices.isValidCall must beFalse
-    }
-
-    "ClipboardService should validate text if the text value is not a URL" in new ClipboardMocks {
-      val text = "This is not a number"
-      mockClipItem.getText returns text
-
-      clipboardServices.isValidCall must beTrue
     }
 
   }

--- a/src/test/scala/com/fortysevendeg/translatebubble/modules/clipboard/ClipboardServiceComponentSpec.scala
+++ b/src/test/scala/com/fortysevendeg/translatebubble/modules/clipboard/ClipboardServiceComponentSpec.scala
@@ -63,49 +63,49 @@ class ClipboardServiceComponentSpec
       val text = "This is not a number"
       mockClipItem.getText returns text
 
-      clipboardServices.isValidCall shouldEqual true
+      clipboardServices.isValidCall must beTrue
     }
 
     "ClipboardService should not validate text if the text value is a number" in new ClipboardMocks {
       val number = "47"
       mockClipItem.getText returns number
 
-      clipboardServices.isValidCall shouldEqual false
+      clipboardServices.isValidCall must beFalse
     }
 
     "ClipboardService should not validate text if the text value is a URL starting with 'https'" in new ClipboardMocks {
       val url = "https://www.47deg.com"
       mockClipItem.getText returns url
 
-      clipboardServices.isValidCall shouldEqual false
+      clipboardServices.isValidCall must beFalse
     }
 
     "ClipboardService should not validate text if the text value is a URL starting with 'http'" in new ClipboardMocks {
       val url = "http://www.47deg.com"
       mockClipItem.getText returns url
 
-      clipboardServices.isValidCall shouldEqual false
+      clipboardServices.isValidCall must beFalse
     }
 
     "ClipboardService should not validate text if the text value is a URL starting with 'www'" in new ClipboardMocks {
       val url = "www.47deg.com"
       mockClipItem.getText returns url
 
-      clipboardServices.isValidCall shouldEqual false
+      clipboardServices.isValidCall must beFalse
     }
 
     "ClipboardService should not validate text if the text value is a URL starting with the domain" in new ClipboardMocks {
       val url = "47deg.com"
       mockClipItem.getText returns url
 
-      clipboardServices.isValidCall shouldEqual false
+      clipboardServices.isValidCall must beFalse
     }
 
     "ClipboardService should validate text if the text value is not a URL" in new ClipboardMocks {
       val text = "This is not a number"
       mockClipItem.getText returns text
 
-      clipboardServices.isValidCall shouldEqual true
+      clipboardServices.isValidCall must beTrue
     }
 
   }


### PR DESCRIPTION
Hi 47Deg developers!

In this PR I've changed your text validation policy in ``ClipboardServicesComponentImpl`` to fix the issue #7.

Take a look to the new conditions I've added. Now, if the text to translate is a number or a URL the text is not consider as valid. I've added some tests to ``ClipboardServiceComponentSpec``.

I've used a regular expression to check if the text to translate is a URL or not and the ``forall`` functional combinator to check if the text is a number. 

To write this tests I've used ``clipboardServices.isValidCall shouldEqual false`` but I'm not sure if this is the correct way to assert this expected value :S This is my first PR to a Scala project :)

Maybe all the code related to the text validation should be extracted to another class. But I think for this PR is not needed.